### PR TITLE
bump version to tag a release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Nerves.HAL.Mixfile do
 
   def project do
     [app: :nerves_hal,
-     version: "0.1.0",
+     version: "0.2.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
I want to cut an official release so we can refer to a git tag rather than just blindly using master.
This also means that, as we make changes going forward, we should keep semver in mind and make sure we bump the version appropriately.

@mobileoverlord, if you want to push to Hex, since this is a public repo, that would be fine as well. I just want to have a git tag that we can refer to internally, at a minimum.