### PR TITLE
fix device devpath construction

### DIFF
--- a/lib/nerves_hal/device.ex
+++ b/lib/nerves_hal/device.ex
@@ -6,7 +6,7 @@ defmodule Nerves.HAL.Device do
 
   def load([_ | devscope] = scope, subsystem) do
     devpath =
-        Path.join([@sysfs, "/", Enum.join(devscope, "/")])
+        Path.join([@sysfs] ++ devscope)
 
     %__MODULE__{
       scope: scope,


### PR DESCRIPTION
This fixes an issue where certain devpaths would be constructed incorrectly resulting in `./` being applied to parts of the path improperly.