### PR TITLE
Replace nerves_runtime dep with system_registry.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Nerves.HAL.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:nerves_runtime, "~> 0.3"},
+    [{:system_registry, "~> 0.5.0"},
      {:gen_stage, "~> 0.12"}]
   end
 end


### PR DESCRIPTION
We aren't using anything from Nerves.Runtime in Nerves.HAL other than its dependency on system_registry.  This cuts out the middle man.