### PR TITLE
Consolidate handle_data_in callback to Device.Spec behaviour.

### DIFF
--- a/lib/nerves_hal/device/adapter/connection.ex
+++ b/lib/nerves_hal/device/adapter/connection.ex
@@ -1,5 +1,0 @@
-defmodule Nerves.HAL.Device.Adapter.Connection do
-  @callback handle_data_in(device :: Device.t(), data :: term, state :: term) ::
-              {:noreply, state :: term}
-              | {:disconnect, state :: term}
-end

--- a/lib/nerves_hal/device/spec.ex
+++ b/lib/nerves_hal/device/spec.ex
@@ -5,6 +5,10 @@ defmodule Nerves.HAL.Device.Spec do
 
   @callback handle_connect(device :: Device.t(), state :: term) :: {:noreply, new_state :: term}
 
+  @callback handle_data_in(device :: Device.t(), data :: term, state :: term) ::
+              {:noreply, state :: term}
+              | {:disconnect, state :: term}
+
   @callback handle_discover(device :: Device.t(), state :: term) ::
               {:connect, new_state :: term}
               | {:noreply, new_state :: term}
@@ -30,7 +34,6 @@ defmodule Nerves.HAL.Device.Spec do
 
     quote location: :keep do
       @behaviour Nerves.HAL.Device.Spec
-      @behaviour Nerves.HAL.Device.Adapter.Connection
 
       @adapter unquote(adapter)
       @adapter_opts unquote(opts)


### PR DESCRIPTION
The `Nerves.HAL.Device.Adapter.Connection` behaviour is only ever used from `Nerves.HAL.Device.Spec` processes.  It's just one callback.  In order to simplify Nerves.HAL a tiny bit, I propose we just move that callback to the Spec behaviour.  